### PR TITLE
fix(interchange): Address failing test (commit from alindber)

### DIFF
--- a/src/interchange/test/interchange.spec.js
+++ b/src/interchange/test/interchange.spec.js
@@ -171,11 +171,11 @@ describe("interchange", function () {
         $compile(element)(scope);
         scope.$digest();
         expect(element.attr('src')).toBeUndefined();
-        expect(element.attr('style')).toMatch(/background-image:\ ?url\([a-zA-Z0-9\.\\\/\@\:]*default\.jpg\)/);
+        expect(element.attr('style')).toMatch(/background-image:\ ?url\(\"?[a-zA-Z0-9\.\\\/\@\:]*default\.jpg\"?\)/);
 
         matchMediaMock = 'only screen and (min-width:64.063em)';
         window.dispatchEvent(new Event('resize'));
-        expect(element.attr('style')).toMatch(/background-image:\ ?url\([a-zA-Z0-9\.\\\/\@\:]*large\.TIFF\)/);
+        expect(element.attr('style')).toMatch(/background-image:\ ?url\(\"?[a-zA-Z0-9\.\\\/\@\:]*large\.TIFF\"?\)/);
       });
 
       it('should not change the content when the interchange is for dynamic background', function () {


### PR DESCRIPTION
Cherry-pick the commit at https://github.com/yalabot/angular-foundation/pull/288/commits/22258798fcd79fadbba304a41f102abaa05c32e3 by @alindber

This has already been merged in https://github.com/yalabot/angular-foundation `master` (currently at `0.9.0-SNAPSHOT`), but we want this to be merged in `0.8.x`.

#### Description

See details at https://github.com/yalabot/angular-foundation/pull/288.

#### Release notes

- Adjust test to accommodate newer browsers

Changelog Category: Bug Fixes - interchange